### PR TITLE
Reset dependencies to original versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem "rails", "4.2.11"
 # Use SCSS for stylesheets
 gem "sass-rails", "~> 5.0"
 # Automatically apply http headers that are related to security
-gem "secure_headers", "~> 6.0"
+gem "secure_headers", "~> 5.0"
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 gem "turbolinks"
 # Use Uglifier as compressor for JavaScript assets
@@ -41,7 +41,7 @@ gem "waste_exemptions_engine",
     branch: "master"
 
 # bundle exec rake doc:rails generates the API under doc/api.
-gem "sdoc", "~> 1.0.0", group: :doc
+gem "sdoc", "~> 0.4.0", group: :doc
 
 group :development, :production do
   # Web application server that replaces webrick. It handles HTTP requests,
@@ -49,7 +49,7 @@ group :development, :production do
   # and problem diagnosis. It is used in production because it gives us an ability
   # to scale by creating additional processes, and will automatically restart any
   # that fail. We don't use it when running tests for speed's sake.
-  gem "passenger", "~> 6.0", require: "phusion_passenger/rack_handler"
+  gem "passenger", "~> 5.0", ">= 5.0.30", require: "phusion_passenger/rack_handler"
 end
 
 group :development, :test do
@@ -68,7 +68,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "spring"
   # Access an IRB console on exception pages or by using <%= console %> in views
-  gem "web-console", "~> 3.3"
+  gem "web-console", "~> 2.0"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: 3351b2795a931057325c045fcef372d2bda2cb40
+  revision: db51f8cdc20cde86ba8f59f3924e3f700308220d
   branch: master
   specs:
     waste_exemptions_engine (0.0.1)
@@ -61,6 +61,8 @@ GEM
     airbrake-ruby (1.8.0)
     arel (6.0.4)
     ast (2.4.0)
+    binding_of_caller (0.8.0)
+      debug_inspector (>= 0.0.1)
     builder (3.2.3)
     byebug (10.0.2)
     concurrent-ruby (1.1.4)
@@ -88,7 +90,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (2.0.0)
       faraday (~> 0.8)
-    ffi (1.9.25)
+    ffi (1.10.0)
     github_changelog_generator (1.14.3)
       activesupport
       faraday-http-cache
@@ -97,7 +99,7 @@ GEM
       rainbow (>= 2.1)
       rake (>= 10.0)
       retriable (~> 2.1)
-    globalid (0.4.1)
+    globalid (0.4.2)
       activesupport (>= 4.2.0)
     govuk_elements_rails (3.1.3)
       govuk_frontend_toolkit (>= 6.0.2)
@@ -120,7 +122,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.1.0)
+    json (1.8.6)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -143,7 +145,7 @@ GEM
     parallel (1.12.1)
     parser (2.5.3.0)
       ast (~> 2.4.0)
-    passenger (6.0.1)
+    passenger (5.3.7)
       rack
       rake (>= 0.8.1)
     pg (0.18.4)
@@ -180,9 +182,9 @@ GEM
     rainbow (3.0.0)
     rake (12.3.2)
     rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
-    rdoc (6.1.1)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
+    rdoc (4.3.0)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -214,7 +216,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
     ruby-progressbar (1.10.0)
-    sass (3.7.2)
+    sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -228,9 +230,11 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
-    sdoc (1.0.0)
-      rdoc (>= 5.0)
-    secure_headers (6.0.0)
+    sdoc (0.4.2)
+      json (~> 1.7, >= 1.7.7)
+      rdoc (~> 4.0)
+    secure_headers (5.0.5)
+      useragent (>= 0.15.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -260,12 +264,14 @@ GEM
       unf_ext
     unf_ext (0.0.7.5)
     unicode-display_width (1.4.1)
+    useragent (0.16.10)
     validates_email_format_of (1.6.3)
       i18n
-    web-console (3.3.0)
-      activemodel (>= 4.2)
-      debug_inspector
-      railties (>= 4.2)
+    web-console (2.3.0)
+      activemodel (>= 4.0)
+      binding_of_caller (>= 0.7.2)
+      railties (>= 4.0)
+      sprockets-rails (>= 2.0, < 4.0)
 
 PLATFORMS
   ruby
@@ -281,19 +287,19 @@ DEPENDENCIES
   govuk_elements_rails (~> 3.1)
   govuk_template (~> 0.23)
   jquery-rails
-  passenger (~> 6.0)
+  passenger (~> 5.0, >= 5.0.30)
   pg (~> 0.18.4)
   rails (= 4.2.11)
   rspec-rails (~> 3.8)
   sass-rails (~> 5.0)
-  sdoc (~> 1.0.0)
-  secure_headers (~> 6.0)
+  sdoc (~> 0.4.0)
+  secure_headers (~> 5.0)
   simplecov
   spring
   turbolinks
   uglifier (>= 1.3.0)
   waste_exemptions_engine!
-  web-console (~> 3.3)
+  web-console (~> 2.0)
 
 RUBY VERSION
    ruby 2.4.2p198


### PR DESCRIPTION
We recently integrated [Dependabot](https://dependabot.com) to the project, but forgot to tell it not to touch the Gemfile, and just focus on Gemfile.lock updates.

So we mistakenly accepted some major version dependency updates, when we should be trying to keep the WEX and WCR in sync.

This change resets the versions specified in the Gemfile.