### PR TITLE
Add support for sending email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,11 @@ AIRBRAKE_FO_PROJECT_KEY=longvaluefullofnumbersandlettersinlowercase
 # Companies House config
 COMPANIES_HOUSE_URL='https://api.companieshouse.gov.uk/company/'
 COMPANIES_HOUSE_API_KEY=longvaluefullofnumbersandlettersinlowercase
+
+# Email settings
+EMAIL_HOST=
+EMAIL_PORT=
+EMAIL_USERNAME=""
+EMAIL_PASSWORD=""
+EMAIL_TEST_ADDRESS=""
+EMAIL_SERVICE_EMAIL=""

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: db51f8cdc20cde86ba8f59f3924e3f700308220d
+  revision: 9da33b7d336c10a968af034feebbc147e57b85bf
   branch: master
   specs:
     waste_exemptions_engine (0.0.1)

--- a/app/mailers/test_mailer.rb
+++ b/app/mailers/test_mailer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class TestMailer < ActionMailer::Base
+  def test_email
+    from_address = "#{Rails.configuration.service_name} <#{Rails.configuration.email_service_email}>"
+    subject = "#{Rails.configuration.service_name} email"
+    mail(to: Rails.configuration.email_test_address,
+         subject: subject,
+         from: from_address) do |format|
+      format.text(content_type: "text/plain", charset: "UTF-8", content_transfer_encoding: "7bit")
+    end
+  end
+end

--- a/app/views/test_mailer/test_email.text.erb
+++ b/app/views/test_mailer/test_email.text.erb
@@ -1,0 +1,3 @@
+This is a test email sent from the <%= Rails.configuration.email_service_name %>.
+
+<%= Rails.configuration.git_repository_url %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,9 +45,19 @@ module WasteExemptionsFrontOffice
     config.companies_house_host = ENV["COMPANIES_HOUSE_URL"] || "https://api.companieshouse.gov.uk/company/"
     config.companies_house_api_key = ENV["COMPANIES_HOUSE_API_KEY"]
 
+    # Paths
+    config.front_office_url = ENV["FRONT_OFFICE_URL"] || "http://localhost:3001"
+    config.back_office_url = ENV["BACK_OFFICE_URL"] || "http://localhost:8001"
+
+    # Times
     config.years_before_expiry = ENV["YEARS_BEFORE_EXPIRY"] || 3
 
+    # Emails
+    config.email_service_email = ENV["EMAIL_SERVICE_EMAIL"]
+    config.email_test_address = ENV["EMAIL_TEST_ADDRESS"]
+
     # Version info
+    config.service_name = "Waste Exemptions Service"
     config.application_name = "waste-exemptions-front-office"
     config.git_repository_url = "https://github.com/DEFRA/#{config.application_name}"
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,8 +13,23 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Don't care if the mailer can't send.
+  # Sending e-mails is required for confirmation emails
+  config.action_mailer.default_url_options = { host: config.front_office_url, protocol: "http" }
+
+  # Don't care if the mailer can't send (if set to false)
   config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :smtp
+
+  # Default settings are for mailcatcher
+  config.action_mailer.smtp_settings = {
+    user_name: ENV["EMAIL_USERNAME"],
+    password: ENV["EMAIL_PASSWORD"],
+    domain: config.front_office_url,
+    address: ENV["EMAIL_HOST"] || "localhost",
+    port: ENV["EMAIL_PORT"] || 1025,
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,5 +38,5 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 end

--- a/lib/tasks/email.rake
+++ b/lib/tasks/email.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :email do
+  desc "Send a test email to confirm confirm setup is correct"
+  task test: :environment do
+    puts TestMailer.test_email.deliver_now
+  end
+end


### PR DESCRIPTION
[Waste exemptions PR #40](https://github.com/DEFRA/waste-exemptions-engine/pull/40) added sending a confirmation email when the user gets to the end page.

To support this the host app needs to ensure action mailer is properly setup for each environment. The changes here ensure this is the case, along with adding our standard rake test for testing email configuration in an environment.