### PR TITLE
Switch to using engine config pattern

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: 77e382044009c3ab7306143b8a3332b4f6b6b8e2
+  revision: a99b2e3d1534f4124d9a1ab3d1a34e76fa46dc72
   branch: master
   specs:
     waste_exemptions_engine (0.0.1)

--- a/app/mailers/test_mailer.rb
+++ b/app/mailers/test_mailer.rb
@@ -2,8 +2,8 @@
 
 class TestMailer < ActionMailer::Base
   def test_email
-    from_address = "#{Rails.configuration.service_name} <#{Rails.configuration.email_service_email}>"
-    subject = "#{Rails.configuration.service_name} email"
+    from_address = "#{WasteExemptionsEngine.service_name} <#{WasteExemptionsEngine.email_service_email}>"
+    subject = "#{WasteExemptionsEngine.service_name} email"
     mail(to: Rails.configuration.email_test_address,
          subject: subject,
          from: from_address) do |format|

--- a/app/views/test_mailer/test_email.text.erb
+++ b/app/views/test_mailer/test_email.text.erb
@@ -1,3 +1,3 @@
-This is a test email sent from the <%= Rails.configuration.email_service_name %>.
+This is a test email sent from the <%= WasteExemptionsEngine.service_name %>.
 
-<%= Rails.configuration.git_repository_url %>
+<%= WasteExemptionsEngine.git_repository_url %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,27 +38,11 @@ module WasteExemptionsFrontOffice
       "#{html_tag}".html_safe
     }
 
-    # Addressbase facade config
-    config.addressbase_url = ENV["ADDRESSBASE_URL"] || "http://localhost:9002"
-
-    # Companies House config
-    config.companies_house_host = ENV["COMPANIES_HOUSE_URL"] || "https://api.companieshouse.gov.uk/company/"
-    config.companies_house_api_key = ENV["COMPANIES_HOUSE_API_KEY"]
-
     # Paths
     config.front_office_url = ENV["FRONT_OFFICE_URL"] || "http://localhost:3001"
     config.back_office_url = ENV["BACK_OFFICE_URL"] || "http://localhost:8001"
 
-    # Times
-    config.years_before_expiry = ENV["YEARS_BEFORE_EXPIRY"] || 3
-
     # Emails
-    config.email_service_email = ENV["EMAIL_SERVICE_EMAIL"]
     config.email_test_address = ENV["EMAIL_TEST_ADDRESS"]
-
-    # Version info
-    config.service_name = "Waste Exemptions Service"
-    config.application_name = "waste-exemptions-front-office"
-    config.git_repository_url = "https://github.com/DEFRA/#{config.application_name}"
   end
 end

--- a/config/initializers/waste_exemptions_engine.rb
+++ b/config/initializers/waste_exemptions_engine.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# General config
+WasteExemptionsEngine.application_name = "waste-exemptions-front-office"
+WasteExemptionsEngine.git_repository_url = "https://github.com/DEFRA/waste-exemptions-front-office"
+
+# Companies house API config
+WasteExemptionsEngine.companies_house_host = ENV["COMPANIES_HOUSE_URL"] || "https://api.companieshouse.gov.uk/company/"
+WasteExemptionsEngine.companies_house_api_key = ENV["COMPANIES_HOUSE_API_KEY"]
+
+# Addressbase facade config
+WasteExemptionsEngine.addressbase_url = ENV["ADDRESSBASE_URL"] || "http://localhost:9002"
+
+# Email config
+WasteExemptionsEngine.email_service_email = ENV["EMAIL_SERVICE_EMAIL"] || "wex-local@example.com"
+
+# PDF config
+WasteExemptionsEngine.use_xvfb_for_wickedpdf = ENV["USE_XVFB_FOR_WICKEDPDF"] || "true"


### PR DESCRIPTION
To resolve issues with testing in the engine, and basically because its a better pattern, the waste exemptions engine has implemented its own configuration as per https://guides.rubyonrails.org/engines.html#configuring-an-engine.

To support this we have had to update the front office app to pass in the necessary config values via the engine's initializer, rather than holding them in `Rails.configuration`. We still read them from env vars, and in some cases use a default instead. The change means though that the engine does not need to rely on a host rails app being present with `Rails.configuration` set in order for its code to work.