### PR TITLE
Convert to block style config for WEX engine

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: 88cbe0c4488e2fa501faba2400b03f7b787100be
+  revision: aba62d9300826efe77032b6f86f0c1b02561a83e
   branch: master
   specs:
     waste_exemptions_engine (0.0.1)

--- a/config/initializers/waste_exemptions_engine.rb
+++ b/config/initializers/waste_exemptions_engine.rb
@@ -1,18 +1,19 @@
 # frozen_string_literal: true
 
-# General config
-WasteExemptionsEngine.application_name = "waste-exemptions-front-office"
-WasteExemptionsEngine.git_repository_url = "https://github.com/DEFRA/waste-exemptions-front-office"
+WasteExemptionsEngine.configure do |configuration|
+  # General config
+  configuration.application_name = "waste-exemptions-front-office"
+  configuration.git_repository_url = "https://github.com/DEFRA/waste-exemptions-front-office"
 
-# Companies house API config
-WasteExemptionsEngine.companies_house_host = ENV["COMPANIES_HOUSE_URL"] || "https://api.companieshouse.gov.uk/company/"
-WasteExemptionsEngine.companies_house_api_key = ENV["COMPANIES_HOUSE_API_KEY"]
+  # Companies house API config
+  configuration.companies_house_host = ENV["COMPANIES_HOUSE_URL"] || "https://api.companieshouse.gov.uk/company/"
+  configuration.companies_house_api_key = ENV["COMPANIES_HOUSE_API_KEY"]
 
-# Addressbase facade config
-WasteExemptionsEngine.addressbase_url = ENV["ADDRESSBASE_URL"] || "http://localhost:9002"
+  # Addressbase facade config
+  configuration.addressbase_url = ENV["ADDRESSBASE_URL"] || "http://localhost:9002"
+  # Email config
+  configuration.email_service_email = ENV["EMAIL_SERVICE_EMAIL"] || "wex-local@example.com"
 
-# Email config
-WasteExemptionsEngine.email_service_email = ENV["EMAIL_SERVICE_EMAIL"] || "wex-local@example.com"
-
-# PDF config
-WasteExemptionsEngine.use_xvfb_for_wickedpdf = ENV["USE_XVFB_FOR_WICKEDPDF"] || "true"
+  # PDF config
+  configuration.use_xvfb_for_wickedpdf = ENV["USE_XVFB_FOR_WICKEDPDF"] || "true"
+end


### PR DESCRIPTION
The [WEX engine](https://github.com/DEFRA/waste-exemptions-engine) has been modified to use a block syntax for setting its configuration.

The reasons why are detailed in [PR 48](https://github.com/DEFRA/waste-exemptions-engine/pull/48) but the TL;DR is

- we need it to support setting config in other gems
- it keeps the way we do configuration in our gems/engines consistent

So this change is to update the Front office to use the new syntax for setting configuration.