### PR TITLE
Fix test mailer and add specs

### DIFF
--- a/app/mailers/test_mailer.rb
+++ b/app/mailers/test_mailer.rb
@@ -2,12 +2,19 @@
 
 class TestMailer < ActionMailer::Base
   def test_email
-    from_address = "#{WasteExemptionsEngine.service_name} <#{WasteExemptionsEngine.email_service_email}>"
-    subject = "#{WasteExemptionsEngine.service_name} email"
+    subject = "#{WasteExemptionsEngine.configuration.service_name} email"
     mail(to: Rails.configuration.email_test_address,
          subject: subject,
          from: from_address) do |format|
       format.text(content_type: "text/plain", charset: "UTF-8", content_transfer_encoding: "7bit")
     end
+  end
+
+  private
+
+  def from_address
+    from_name = WasteExemptionsEngine.configuration.service_name
+    from_email = WasteExemptionsEngine.configuration.email_service_email
+    "#{from_name} <#{from_email}>"
   end
 end

--- a/app/views/test_mailer/test_email.text.erb
+++ b/app/views/test_mailer/test_email.text.erb
@@ -1,3 +1,3 @@
-This is a test email sent from the <%= WasteExemptionsEngine.service_name %>.
+This is a test email sent from the <%= WasteExemptionsEngine.configuration.service_name %>.
 
-<%= WasteExemptionsEngine.git_repository_url %>
+<%= WasteExemptionsEngine.configuration.git_repository_url %>

--- a/config/initializers/waste_exemptions_engine.rb
+++ b/config/initializers/waste_exemptions_engine.rb
@@ -12,6 +12,7 @@ WasteExemptionsEngine.configure do |configuration|
   # Addressbase facade config
   configuration.addressbase_url = ENV["ADDRESSBASE_URL"] || "http://localhost:9002"
   # Email config
+  configuration.service_name = ENV["EMAIL_SERVICE_NAME"] || "Waste Exemptions Service"
   configuration.email_service_email = ENV["EMAIL_SERVICE_EMAIL"] || "wex-local@example.com"
 
   # PDF config

--- a/spec/mailers/test_mailer_spec.rb
+++ b/spec/mailers/test_mailer_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TestMailer, type: :mailer do
+  describe "test_email" do
+    before do
+      allow(Rails.configuration).to receive(:email_test_address).and_return("test@example.com")
+      allow(WasteExemptionsEngine.configuration).to receive(:email_service_email).and_return("wex@example.com")
+      allow(WasteExemptionsEngine.configuration).to receive(:service_name).and_return("WEX")
+    end
+
+    let(:mail) { TestMailer.test_email }
+
+    it "uses the correct 'to' address" do
+      expect(mail.to).to eq(["test@example.com"])
+    end
+
+    it "uses the correct 'from' address" do
+      expect(mail.from).to eq(["wex@example.com"])
+    end
+
+    it "uses the correct subject" do
+      subject = "WEX email"
+      expect(mail.subject).to eq(subject)
+    end
+
+    it "includes the correct template in the body" do
+      expect(mail.body.encoded).to include("This is a test email")
+    end
+  end
+end


### PR DESCRIPTION
While working on https://github.com/DEFRA/waste-exemptions-back-office-ta/pull/30 I discovered that the way we store these config variables had changed but hadn't been updated. This resulted in errors in the mailer.

This commit fixes those errors, and adds some tests to improve coverage and bring the TestMailer into line with its counterpart in the back office.