### PR TITLE
Add missing helper statement to application ctrllr

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,6 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  helper WasteExemptionsEngine::ApplicationHelper
 end


### PR DESCRIPTION
We had issues when the app was deployed to production in that it kept erroring with the message

```
ActionView::Template::Error (undefined local variable or method `title' for #<#<Class:0x000055eecbb375f8>:0x00007ffbdc0725a8>):
```

We tracked this down to the fact that the front office was not including the application helpers defined in the engine. Why this only came to light when the application was deployed as `RAILS_ENV=production` is unknown at this time, but adding this missing statement resolves the issue.