### PR TITLE
Add pgreset gem to solve database in use errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,10 @@ gem "govuk_template", "~> 0.23"
 gem "jquery-rails"
 # Use postgresql as the database for Active Record
 gem "pg", "~> 0.18.4"
+# Automatically kills connections to Postgres when running rake tasks that
+# involve a database drop. Stops the error
+# PG::ObjectInUse: ERROR:  database "wex_db" is being accessed by other users
+gem "pgreset"
 # Bundle edge Rails instead: gem "rails', github: 'rails/rails'
 gem "rails", "4.2.11"
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,7 @@ GEM
       rack
       rake (>= 0.8.1)
     pg (0.18.4)
+    pgreset (0.1.1)
     phonelib (0.6.29)
     powerpack (0.1.2)
     public_suffix (3.0.3)
@@ -295,6 +296,7 @@ DEPENDENCIES
   jquery-rails
   passenger (~> 5.0, >= 5.0.30)
   pg (~> 0.18.4)
+  pgreset
   rails (= 4.2.11)
   rspec-rails (~> 3.8)
   sass-rails (~> 5.0)
@@ -311,4 +313,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
Whenever we try and run a `db:reset` or `db:drop` it always fails because PostgreSQL complains that the database is in use.

To aid with this we can use the [pgreset gem](https://github.com/dafalcon/pgreset) which will        automatically drop any existing connections when a `db:reset` is called.

The main purpose of this is to support resetting the database in our dev, test and pre-prod environments where we often want to reset the database to a clean/starting state for testing, training and debug purposes.