### PR TITLE
Remove dummy secret key logic in application.rb

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,26 +21,6 @@ module WasteExemptionsFrontOffice
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
-    # We have an issue when deploying to our environments in that when
-    # Capistrano runs the deploy:assets:precompile step (specifically bundle
-    # exec rake assets:precompile) it does so having set RAILS_ENV to production.
-    # However we have no default value for the SECRET_KEY in production, and
-    # when the command runs an env var with the value has not been set. This
-    # causes Devise to throw an error which prevents the task from completing.
-    # We have found the simplest solution to the problem is to add this logic
-    # which determines if we are running in production and if the originating
-    # call was made from rake. If that's the case we can assume a task like
-    # assets:precompile is being run and therefore programmtically set the
-    # secret key, stopping devise from erroring.
-    # https://stackoverflow.com/a/15767148/6117745
-    def apply_dummy_secret_key?
-      return false unless Rails.env.production?
-      return false unless File.basename($0) == "rake"
-      return false unless config.secret_key_base.blank?
-
-      true
-    end
-
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     config.time_zone = "UTC"
@@ -64,7 +44,5 @@ module WasteExemptionsFrontOffice
 
     # Emails
     config.email_test_address = ENV["EMAIL_TEST_ADDRESS"]
-
-    config.secret_key_base = "iamonlyherefordevisewhenraketasksarecalled" if apply_dummy_secret_key?
   end
 end


### PR DESCRIPTION
The dummy secret logic was necessary because of the way we were previously deploying environment variables to our environments.

It finally clicked that to support this previous way, we were not only implementing hacks in our app code, we were also maintaining additional customisations and routines in our deployment code.

So a change has been made to how environment variables are deployed meaning these hacks and customisations are no longer needed.
