### PR TITLE
Unlock Rails version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem "pg", "~> 0.18.4"
 # PG::ObjectInUse: ERROR:  database "wex_db" is being accessed by other users
 gem "pgreset"
 # Bundle edge Rails instead: gem "rails', github: 'rails/rails'
-gem "rails", "4.2.11"
+gem "rails", "~> 4.2.11"
 # Use SCSS for stylesheets
 gem "sass-rails", "~> 5.0"
 # Automatically apply http headers that are related to security

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,7 +299,7 @@ DEPENDENCIES
   passenger (~> 5.0, >= 5.0.30)
   pg (~> 0.18.4)
   pgreset
-  rails (= 4.2.11)
+  rails (~> 4.2.11)
   rspec-rails (~> 3.8)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)


### PR DESCRIPTION
Previously our Gemfiles locked Rails to a specific version (4.2.11). This meant that Dependabot would not prompt us with upgrades. As there is now a critical security patch we'd like to apply, we've decided it's better to accept 4.2.11 and above (within the 4.2 range). This should allow Dependabot to submit PRs for patch-level changes to Rails.