### PR TITLE
Update schema with farmer columns, users and versions

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190121092357) do
+ActiveRecord::Schema.define(version: 20190311150953) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,8 +91,8 @@ ActiveRecord::Schema.define(version: 20190121092357) do
     t.string   "contact_position"
     t.string   "contact_phone"
     t.string   "contact_email"
-    t.boolean  "is_a_farm"
     t.boolean  "on_a_farm"
+    t.boolean  "is_a_farmer"
     t.datetime "created_at",           null: false
     t.datetime "updated_at",           null: false
     t.date     "submitted_at"
@@ -169,8 +169,8 @@ ActiveRecord::Schema.define(version: 20190121092357) do
     t.string   "contact_position"
     t.string   "contact_phone"
     t.string   "contact_email"
-    t.boolean  "is_a_farm"
     t.boolean  "on_a_farm"
+    t.boolean  "is_a_farmer"
     t.boolean  "declaration"
     t.string   "temp_operator_postcode"
     t.string   "temp_contact_postcode"
@@ -184,6 +184,44 @@ ActiveRecord::Schema.define(version: 20190121092357) do
 
   add_index "transient_registrations", ["reference"], name: "index_transient_registrations_on_reference", unique: true, using: :btree
   add_index "transient_registrations", ["token"], name: "index_transient_registrations_on_token", unique: true, using: :btree
+
+  create_table "users", force: :cascade do |t|
+    t.string   "email",                  default: "",   null: false
+    t.string   "encrypted_password",     default: "",   null: false
+    t.string   "invitation_token"
+    t.datetime "invitation_created_at"
+    t.datetime "invitation_sent_at"
+    t.datetime "invitation_accepted_at"
+    t.integer  "invitation_limit"
+    t.integer  "invited_by_id"
+    t.string   "invited_by_type"
+    t.integer  "failed_attempts",        default: 0,    null: false
+    t.string   "unlock_token"
+    t.datetime "locked_at"
+    t.string   "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.string   "session_token"
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
+    t.string   "role"
+    t.boolean  "active",                 default: true
+  end
+
+  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+  add_index "users", ["invitation_token"], name: "index_users_on_invitation_token", unique: true, using: :btree
+  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+  add_index "users", ["unlock_token"], name: "index_users_on_unlock_token", unique: true, using: :btree
+
+  create_table "versions", force: :cascade do |t|
+    t.string   "item_type",  null: false
+    t.integer  "item_id",    null: false
+    t.string   "event",      null: false
+    t.string   "whodunnit"
+    t.text     "object"
+    t.datetime "created_at"
+  end
+
+  add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
 
   add_foreign_key "addresses", "registrations"
   add_foreign_key "people", "registrations"


### PR DESCRIPTION
We'd merged a number of changes into the engine which created or modified some columns and tables. This commit should update the schema to reflect the new result after a `rake db:migrate`.