### PR TITLE
Add assistance_mode to registration

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190311150953) do
+ActiveRecord::Schema.define(version: 20190314161232) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -96,6 +96,7 @@ ActiveRecord::Schema.define(version: 20190311150953) do
     t.datetime "created_at",           null: false
     t.datetime "updated_at",           null: false
     t.date     "submitted_at"
+    t.string   "assistance_mode"
   end
 
   add_index "registrations", ["reference"], name: "index_registrations_on_reference", unique: true, using: :btree


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-200

A registration should have a different assistance_mode depending on whether it was submitted through the front-office or back-office. This allows us to track what proportion of registrations are assisted digital.

Front-office users will save an `assistance_mode` value of `nil` by default, so we don't need to change anything in the initializer as we do with the back office. However, we do still need to add the value to the schema.

This will take effect once https://github.com/DEFRA/waste-exemptions-engine/pull/98 is merged in.