### PR TITLE
Update schema to include deregistered_on

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190319133740) do
+ActiveRecord::Schema.define(version: 20190326133420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,7 @@ ActiveRecord::Schema.define(version: 20190319133740) do
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
     t.text     "deregistration_message"
+    t.date     "deregistered_on"
   end
 
   add_index "registration_exemptions", ["exemption_id"], name: "index_registration_exemptions_on_exemption_id", using: :btree


### PR DESCRIPTION
The engine recently had an additional migration added to include a `deregistered_on` date field against the exemptions.

However we are having issues in our environments with our db reset job because it is seeing an outstanding migration needs to be run.

So have run `db:migrate` to get the schema updated in order to resolve this issue.