### PR TITLE
Update to support last email cache feature

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: 81d68d8e1f60f63cbf7adfb2466c878aaeb60ece
+  revision: e2666ba899c571a37280053ca94f775bcb761ae5
   branch: master
   specs:
     waste_exemptions_engine (0.0.1)
@@ -136,7 +136,7 @@ GEM
       mini_mime (>= 0.1.1)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2018.0812)
+    mime-types-data (3.2019.0331)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)

--- a/config/initializers/waste_exemptions_engine.rb
+++ b/config/initializers/waste_exemptions_engine.rb
@@ -19,5 +19,5 @@ WasteExemptionsEngine.configure do |configuration|
   configuration.use_xvfb_for_wickedpdf = ENV["USE_XVFB_FOR_WICKEDPDF"] || "true"
 
   # Last email cache config
-  configuration.use_xvfb_for_wickedpdf = ENV["USE_LAST_EMAIL_CACHE"] || "false"
+  configuration.use_last_email_cache = ENV["USE_LAST_EMAIL_CACHE"] || "false"
 end

--- a/config/initializers/waste_exemptions_engine.rb
+++ b/config/initializers/waste_exemptions_engine.rb
@@ -17,4 +17,7 @@ WasteExemptionsEngine.configure do |configuration|
 
   # PDF config
   configuration.use_xvfb_for_wickedpdf = ENV["USE_XVFB_FOR_WICKEDPDF"] || "true"
+
+  # Last email cache config
+  configuration.use_xvfb_for_wickedpdf = ENV["USE_LAST_EMAIL_CACHE"] || "false"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190326133420) do
+ActiveRecord::Schema.define(version: 20190327134526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,6 +42,12 @@ ActiveRecord::Schema.define(version: 20190326133420) do
   end
 
   add_index "addresses", ["registration_id"], name: "index_addresses_on_registration_id", using: :btree
+
+  create_table "defra_ruby_exporters_bulk_export_files", force: :cascade do |t|
+    t.string   "file_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "exemptions", force: :cascade do |t|
     t.integer "category"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-256

[WEX engine PR 112](https://github.com/DEFRA/waste-exemptions-engine/pull/112) added the ability to see the details of the last email sent as JSON.

However to enable it in the app we need to update the engine to the lastest, and then include the configuration in the engine initializer.

This change makes the necessary changes to the app to support using this feature in our non-production environments.