### PR TITLE
Add test coverage for correct handling of 404 errors.

### DIFF
--- a/spec/requests/page_not_found_spec.rb
+++ b/spec/requests/page_not_found_spec.rb
@@ -2,15 +2,13 @@
 
 require "rails_helper"
 
-module WasteExemptionsEngine
-  RSpec.describe "Page not found", type: :request do
-    describe "GET /this-page-does-not-exist" do
-      it "redirects to `/errors/404`" do
-        rails_respond_without_detailed_exceptions do
-          get "/this-page-does-not-exist"
+RSpec.describe "Page not found", type: :request do
+  describe "GET /this-page-does-not-exist" do
+    it "redirects to `/errors/404`" do
+      rails_respond_without_detailed_exceptions do
+        get "/this-page-does-not-exist"
 
-          expect(response.code).to eq("404")
-        end
+        expect(response.code).to eq("404")
       end
     end
   end

--- a/spec/requests/page_not_found_spec.rb
+++ b/spec/requests/page_not_found_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module WasteExemptionsEngine
+  RSpec.describe "Page not found", type: :request do
+    describe "GET /this-page-does-not-exist" do
+      it "redirects to `/errors/404`" do
+        rails_respond_without_detailed_exceptions do
+          get '/this-page-does-not-exist'
+
+          expect(response.code).to eq("404")
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/page_not_found_spec.rb
+++ b/spec/requests/page_not_found_spec.rb
@@ -7,7 +7,7 @@ module WasteExemptionsEngine
     describe "GET /this-page-does-not-exist" do
       it "redirects to `/errors/404`" do
         rails_respond_without_detailed_exceptions do
-          get '/this-page-does-not-exist'
+          get "/this-page-does-not-exist"
 
           expect(response.code).to eq("404")
         end

--- a/spec/support/error_responses_helper.rb
+++ b/spec/support/error_responses_helper.rb
@@ -3,14 +3,14 @@
 module ErrorResponses
   def rails_respond_without_detailed_exceptions
     env_config = Rails.application.env_config
-    original_show_exceptions = env_config['action_dispatch.show_exceptions']
-    original_show_detailed_exceptions = env_config['action_dispatch.show_detailed_exceptions']
-    env_config['action_dispatch.show_exceptions'] = true
-    env_config['action_dispatch.show_detailed_exceptions'] = false
+    original_show_exceptions = env_config["action_dispatch.show_exceptions"]
+    original_show_detailed_exceptions = env_config["action_dispatch.show_detailed_exceptions"]
+    env_config["action_dispatch.show_exceptions"] = true
+    env_config["action_dispatch.show_detailed_exceptions"] = false
     yield
   ensure
-    env_config['action_dispatch.show_exceptions'] = original_show_exceptions
-    env_config['action_dispatch.show_detailed_exceptions'] = original_show_detailed_exceptions
+    env_config["action_dispatch.show_exceptions"] = original_show_exceptions
+    env_config["action_dispatch.show_detailed_exceptions"] = original_show_detailed_exceptions
   end
 end
 

--- a/spec/support/error_responses_helper.rb
+++ b/spec/support/error_responses_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module ErrorResponses
+  def rails_respond_without_detailed_exceptions
+    env_config = Rails.application.env_config
+    original_show_exceptions = env_config['action_dispatch.show_exceptions']
+    original_show_detailed_exceptions = env_config['action_dispatch.show_detailed_exceptions']
+    env_config['action_dispatch.show_exceptions'] = true
+    env_config['action_dispatch.show_detailed_exceptions'] = false
+    yield
+  ensure
+    env_config['action_dispatch.show_exceptions'] = original_show_exceptions
+    env_config['action_dispatch.show_detailed_exceptions'] = original_show_detailed_exceptions
+  end
+end
+
+RSpec.configure do |config|
+  config.include ErrorResponses
+end


### PR DESCRIPTION
Part of: https://eaflood.atlassian.net/browse/RUBY-261

Add test coverage for the correct handling of 404 errors.
The actual fix is in the engine, but since this bug is not happening in the
engine's dummy specs is worth adding it in this project instead.