### PR TITLE
Update date on privacy policy

### DIFF
--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -89,6 +89,6 @@
     at any time.
   </p>
   <div class="app-c-published-dates">
-    This notice was last updated on 25 April 2019.
+    This notice was last updated on 11 July 2019.
   </div>
 </div>


### PR DESCRIPTION
Now we have our release date we know when this version of the privacy policy will go live. As such this change updates the date to match our expected release date.