### PR TITLE
Fix link to waste exemptions engine in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The waste exemptions service is used by organisations to apply for an exemption.
 
 This service is currently beta public and has been developed in accordance with the [Digital by Default service standard](https://www.gov.uk/service-manual/digital-by-default), putting user needs first and delivered iteratively.
 
-This project is the front office application which members of the public use to register an exemption. It uses the [waste-exemptions-engine](https://github.com/DEFRA/waste-exemptions-engijne).
+This project is the front office application which members of the public use to register an exemption. It uses the [waste-exemptions-engine](https://github.com/DEFRA/waste-exemptions-engine).
 
 ## Prequisites
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -193,7 +193,7 @@ ActiveRecord::Schema.define(version: 20190626142528) do
     t.boolean  "address_finder_error",   default: false
     t.datetime "created_at",                             null: false
     t.datetime "updated_at",                             null: false
-    t.string   "type",                                   null: false
+    t.string   "type"
   end
 
   add_index "transient_registrations", ["reference"], name: "index_transient_registrations_on_reference", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -193,7 +193,7 @@ ActiveRecord::Schema.define(version: 20190626142528) do
     t.boolean  "address_finder_error",   default: false
     t.datetime "created_at",                             null: false
     t.datetime "updated_at",                             null: false
-    t.string   "type"
+    t.string   "type",                                   null: false
   end
 
   add_index "transient_registrations", ["reference"], name: "index_transient_registrations_on_reference", unique: true, using: :btree


### PR DESCRIPTION
There was a typo in the link to waste-exemptions-engine so I've fixed it.