### PR TITLE
Tell search engines not to index app

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,5 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 #
 # To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+User-agent: *
+Disallow: /


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-529

We want users to go through the start page on GOV.UK rather than coming directly to the service. This aligns with what the GDS service manual says: "tell search engines not to index pages on your domain".