### PR TITLE
Add data layer to head

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,5 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   helper WasteExemptionsEngine::ApplicationHelper
+  helper DataLayerHelper
 end

--- a/app/helpers/data_layer_helper.rb
+++ b/app/helpers/data_layer_helper.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module DataLayerHelper
+  def data_layer(transient_registration)
+    output = []
+
+    data_layer_hash(transient_registration).each do |key, value|
+      output << "'#{key}': '#{value}'"
+    end
+
+    output.join(",").html_safe
+  end
+
+  private
+
+  def data_layer_hash(transient_registration)
+    {
+      journey: data_layer_value_for_journey(transient_registration)
+    }
+  end
+
+  def data_layer_value_for_journey(transient_registration)
+    case transient_registration.class.name
+    when "WasteExemptionsEngine::EditRegistration"
+      :edit
+    when "WasteExemptionsEngine::NewRegistration"
+      :new
+    when "WasteExemptionsEngine::RenewingRegistration"
+      :renew
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,10 +1,10 @@
 <% content_for(:head) do %>
   <% if @transient_registration.present? %>
-  <script>
-    dataLayer = [{
-      <%= data_layer(@transient_registration) %>
-    }];
-  </script>
+    <script>
+      dataLayer = [{
+        <%= data_layer(@transient_registration) %>
+      }];
+    </script>
   <% end %>
 
   <% if ENV['GOOGLE_TAGMANAGER_ID'].present? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,4 +1,12 @@
 <% content_for(:head) do %>
+  <% if @transient_registration.present? %>
+  <script>
+    dataLayer = [{
+      <%= data_layer(@transient_registration) %>
+    }];
+  </script>
+  <% end %>
+
   <% if ENV['GOOGLE_TAGMANAGER_ID'].present? %>
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :address, class: WasteExemptionsEngine::Address do
+    sequence :postcode do |n|
+      "BS#{n}AA"
+    end
+
+    sequence :uprn do |n|
+      "uprn_#{n}"
+    end
+
+    sequence :premises do |n|
+      "premises_#{n}"
+    end
+
+    sequence :street_address do |n|
+      "street_address_#{n}"
+    end
+
+    sequence :locality do |n|
+      "locality_#{n}"
+    end
+
+    sequence :city do |n|
+      "city_#{n}"
+    end
+
+    address_type { 0 }
+
+    trait :operator do
+      address_type { :operator }
+    end
+
+    trait :contact do
+      address_type { :contact }
+    end
+
+    trait :site do
+      address_type { :site }
+      mode { :auto }
+      description { "The waste is stored in an out-building next to the barn." }
+      grid_reference { "ST 58337 72855" }
+
+      sequence :x do |n|
+        n
+      end
+
+      sequence :y do |n|
+        n
+      end
+
+      uprn { nil }
+      premises { nil }
+      street_address { nil }
+      locality { nil }
+      city { nil }
+      postcode { nil }
+      country_iso { nil }
+    end
+  end
+end

--- a/spec/factories/edit_registration.rb
+++ b/spec/factories/edit_registration.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :edit_registration, class: WasteExemptionsEngine::EditRegistration do
+    # Create a new registration when initializing so we can copy its data
+    initialize_with do
+      new(reference: create(:registration).reference)
+    end
+  end
+end

--- a/spec/factories/exemption.rb
+++ b/spec/factories/exemption.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :exemption, class: WasteExemptionsEngine::Exemption do
+    category { 0 }
+    url { "https://example.gov.uk/guidance/waste-exemptions-using-waste" }
+    summary { "Use of spam in cooking" }
+    description { "Use of spam in cooking using suitable spam rather than virgin spam or spam which has ceased to be spam - for example by cooking spam with chips." }
+    guidance { "This exemption allows you to use suitable spam rather than virgin spam or spam which has ceased to be spam - for example by cooking spam with chips." }
+
+    sequence :code do |n|
+      "F#{n}"
+    end
+  end
+end

--- a/spec/factories/new_registration.rb
+++ b/spec/factories/new_registration.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :new_registration, class: WasteExemptionsEngine::NewRegistration do
+  end
+end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :registration, class: WasteExemptionsEngine::Registration do
+    location { "england" }
+    applicant_phone { "01234567890" }
+    contact_phone { "01234567890" }
+    business_type { "limitedCompany" }
+    company_no { "09360070" }
+    on_a_farm { true }
+    is_a_farmer { true }
+
+    submitted_at { DateTime.now }
+
+    registration_exemptions { build_list(:registration_exemption, 3) }
+
+    sequence :applicant_email do |n|
+      "applicant#{n}@example.com"
+    end
+
+    sequence :applicant_first_name do |n|
+      "Firstapp#{n}"
+    end
+
+    sequence :applicant_last_name do |n|
+      "Lastapp#{n}"
+    end
+
+    sequence :contact_email do |n|
+      "contact#{n}@example.com"
+    end
+
+    sequence :contact_first_name do |n|
+      "Firstcontact#{n}"
+    end
+
+    sequence :contact_last_name do |n|
+      "Lastcontact#{n}"
+    end
+
+    sequence :operator_name do |n|
+      "Operator #{n}"
+    end
+
+    sequence :reference do |n|
+      "WEX#{n}"
+    end
+
+    addresses do
+      [build(:address, :operator),
+       build(:address, :contact),
+       build(:address, :site)]
+    end
+  end
+end

--- a/spec/factories/registration_exemption.rb
+++ b/spec/factories/registration_exemption.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :registration_exemption, class: WasteExemptionsEngine::RegistrationExemption do
+    exemption
+    expires_on { Date.today + 3.years }
+    registered_on { Date.today }
+  end
+end

--- a/spec/factories/renewing_registration.rb
+++ b/spec/factories/renewing_registration.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :renewing_registration, class: WasteExemptionsEngine::RenewingRegistration do
+    # Create a new registration when initializing so we can copy its data
+    initialize_with do
+      registration = create(:registration)
+
+      new(reference: registration.reference, token: registration.renew_token)
+    end
+  end
+end

--- a/spec/helpers/data_layer_helper_spec.rb
+++ b/spec/helpers/data_layer_helper_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DataLayerHelper, type: :helper do
+  describe "data_layer" do
+    context "when the transient_registration is an EditRegistration" do
+      let(:transient_registration) { build(:edit_registration) }
+
+      it "returns the correct value" do
+        expected_string = "'journey': 'edit'"
+
+        expect(helper.data_layer(transient_registration)).to eq(expected_string)
+      end
+    end
+
+    context "when the transient_registration is a NewRegistration" do
+      let(:transient_registration) { build(:new_registration) }
+
+      it "returns the correct value" do
+        expected_string = "'journey': 'new'"
+
+        expect(helper.data_layer(transient_registration)).to eq(expected_string)
+      end
+    end
+
+    context "when the transient_registration is a RenewingRegistration" do
+      let(:transient_registration) { build(:renewing_registration) }
+
+      it "returns the correct value" do
+        expected_string = "'journey': 'renew'"
+
+        expect(helper.data_layer(transient_registration)).to eq(expected_string)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-509

We want to be able to track the performance of the new registration journey and the renewals journey. Because they use the same pages, we'll need a different way to differentiate.

This PR will add a data layer to the front office header. This will be used by Google Tag Manager to send pageviews with the journey as a custom dimension to Google Analytics.