### PR TITLE
Track usage of 're-register' option

### DIFF
--- a/app/helpers/data_layer_helper.rb
+++ b/app/helpers/data_layer_helper.rb
@@ -20,6 +20,12 @@ module DataLayerHelper
   end
 
   def data_layer_value_for_journey(transient_registration)
+    return :reregister if reregister?(transient_registration)
+
+    data_layer_value_by_type(transient_registration)
+  end
+
+  def data_layer_value_by_type(transient_registration)
     case transient_registration.class.name
     when "WasteExemptionsEngine::EditRegistration"
       :edit
@@ -28,5 +34,9 @@ module DataLayerHelper
     when "WasteExemptionsEngine::RenewingRegistration"
       :renew
     end
+  end
+
+  def reregister?(transient_registration)
+    transient_registration.start_option == "reregister"
   end
 end

--- a/spec/helpers/data_layer_helper_spec.rb
+++ b/spec/helpers/data_layer_helper_spec.rb
@@ -4,6 +4,16 @@ require "rails_helper"
 
 RSpec.describe DataLayerHelper, type: :helper do
   describe "data_layer" do
+    context "when the transient_registration has a `start_option` of 'reregister'" do
+      let(:transient_registration) { build(:new_registration, start_option: "reregister") }
+
+      it "returns the correct value" do
+        expected_string = "'journey': 'reregister'"
+
+        expect(helper.data_layer(transient_registration)).to eq(expected_string)
+      end
+    end
+
     context "when the transient_registration is an EditRegistration" do
       let(:transient_registration) { build(:edit_registration) }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-576

We want to distinguish users who select 're-register' from ones who just want to make a brand new registration.

This change amends our data layer so we store the correct journey, which will be tracked as a custom dimension in Google Analytics.