### PR TITLE
Stat 2 returns 0 if there are no registrations in the past week

### DIFF
--- a/app/models/stats.rb
+++ b/app/models/stats.rb
@@ -21,6 +21,8 @@ class Stats
   end
 
   def calculate_assisted_pc
+    return 0 if count_reg_from_last_week.zero?
+
     ((count_assisted_reg.to_f / count_reg_from_last_week.to_f) * 100).round(1)
   end
 

--- a/spec/models/stats_spec.rb
+++ b/spec/models/stats_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe Stats, type: :model do
 
       expect(subject.new_reg).to eq(1)
     end
+
+    it "returns 0 when there are no registrations" do
+      expect(subject.new_reg).to eq(0)
+    end
   end
 
   describe "#assisted_pc" do
@@ -46,6 +50,10 @@ RSpec.describe Stats, type: :model do
 
       expect(subject.assisted_pc).to eq(100)
     end
+
+    it "returns 0 when there are no registrations" do
+      expect(subject.assisted_pc).to eq(0)
+    end
   end
 
   describe "#email_renewals" do
@@ -57,6 +65,10 @@ RSpec.describe Stats, type: :model do
       end
 
       expect(subject.email_renewals).to eq(3)
+    end
+
+    it "returns 0 when there are no registrations" do
+      expect(subject.email_renewals).to eq(0)
     end
   end
 end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-625

Following an observation made during QA, this adds a guard clause to stat 2 so that it returns 0 if there are no registrations in the past week rather than dividing by zero and returning `NaN`.

I added a test for this and the other stats, just to confirm they all return 0 if there are no registrations in the past week.