### PR TITLE
Update schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190909093455) do
+ActiveRecord::Schema.define(version: 20190912112625) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,8 +22,9 @@ ActiveRecord::Schema.define(version: 20190909093455) do
     t.integer  "number_of_letters"
     t.string   "printed_by"
     t.date     "printed_on"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.integer  "status",            default: 0
   end
 
   create_table "addresses", force: :cascade do |t|


### PR DESCRIPTION
Currently if you run `bundle exec rake db:migrate` in the front office it makes a change to the `db/schema.rb` file.

This is generally an indication that we have made a DB change in the engine but this project has not been updated along with it.

This removes any confusion and ensures the schema.rb is in sync with the latest position.