### PR TITLE
Top stat 3 to exclude back office renewals

### DIFF
--- a/app/models/stats.rb
+++ b/app/models/stats.rb
@@ -27,7 +27,7 @@ class Stats
   end
 
   def count_email_renewals
-    reg_from_last_week.where.not(referring_registration_id: nil).count
+    reg_from_last_week.where(assistance_mode: nil).where.not(referring_registration_id: nil).count
   end
 
   def count_assisted_reg

--- a/spec/models/stats_spec.rb
+++ b/spec/models/stats_spec.rb
@@ -60,6 +60,10 @@ RSpec.describe Stats, type: :model do
     it "returns the correct number of renewals" do
       create(:registration, submitted_at: 1.day.ago.beginning_of_day)
 
+      2.times do
+        create(:registration, :was_assisted, :was_renewed, submitted_at: 1.day.ago.beginning_of_day)
+      end
+
       3.times do
         create(:registration, :was_renewed, submitted_at: 1.day.ago.beginning_of_day)
       end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-625

Currently all renewals are included in the statistic but only email renewals should be counted -- back office renewals should be excluded.