### PR TITLE
Housekeeping on the env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Environment variables for the waste-exemptions-front-office.
 #
-# Many of these variables have suitable defaults built-in to the application,
-# but we list them here for completeness and ease-of-editing.
+# Most environment variables have suitable defaults built-in, but those listed
+# here require values to be provided.
 
 # Addressbase config
 ADDRESSBASE_URL='https://my-addressbase-instance.com'
@@ -11,7 +11,6 @@ AIRBRAKE_HOST='https://my-errbit-instance.com'
 AIRBRAKE_FO_PROJECT_KEY=longvaluefullofnumbersandlettersinlowercase
 
 # Companies House config
-COMPANIES_HOUSE_URL='https://api.companieshouse.gov.uk/company/'
 COMPANIES_HOUSE_API_KEY=longvaluefullofnumbersandlettersinlowercase
 
 # Email settings
@@ -21,13 +20,3 @@ EMAIL_USERNAME=""
 EMAIL_PASSWORD=""
 EMAIL_TEST_ADDRESS=""
 EMAIL_SERVICE_EMAIL=""
-
-# Should we use XVFB when rendering PDFs? The reason for asking this is local
-# development environments. If you're working in an environment without a GUI
-# then you want this set to true. However if you are working locally directly
-# on a linux box then you'll want to disable it
-USE_XVFB_FOR_WICKEDPDF=true
-
-# Renewal window values for before and after a registration expires
-RENEWAL_WINDOW_BEFORE_EXPIRY_IN_DAYS=28
-RENEWAL_WINDOW_AFTER_EXPIRY_IN_DAYS=30

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,8 +41,8 @@ module WasteExemptionsFrontOffice
     }
 
     # Paths
-    config.front_office_url = ENV["FRONT_OFFICE_URL"] || "http://localhost:3001"
-    config.back_office_url = ENV["BACK_OFFICE_URL"] || "http://localhost:8001"
+    config.front_office_url = ENV["FRONT_OFFICE_URL"] || "http://localhost:3000"
+    config.back_office_url = ENV["BACK_OFFICE_URL"] || "http://localhost:8000"
 
     # Emails
     config.email_test_address = ENV["EMAIL_TEST_ADDRESS"]

--- a/config/initializers/waste_exemptions_engine.rb
+++ b/config/initializers/waste_exemptions_engine.rb
@@ -16,6 +16,10 @@ WasteExemptionsEngine.configure do |configuration|
   configuration.email_service_email = ENV["EMAIL_SERVICE_EMAIL"] || "wex-local@example.com"
 
   # PDF config
+  # Should we use XVFB when rendering PDFs? The reason for asking this is local
+  # development environments. If you're working in an environment without a GUI
+  # then you want this set to true. However if you are working locally then
+  # you'll want to disable it
   configuration.use_xvfb_for_wickedpdf = ENV["USE_XVFB_FOR_WICKEDPDF"] || "true"
 
   # Last email cache config


### PR DESCRIPTION
This housekeeping exercise does 2 things

- it updates the default env vars to match what we actually use in our environments
- it updates the `.env.example` file to be accurate

On that last point, the original intention of the `.env.example` file was to list all environment variables that are used by the app.

But clearly we haven't been keeping on top of it, as what's listed is vastly out of sync with all the env vars we use. So to make it 'accurate' it now just lists those env vars that must be set for the app to run.