### PR TITLE
Revert defra_ruby_validators to 2.1.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
       rest-client (~> 2.0)
     defra_ruby_style (0.1.3)
       rubocop (~> 0.75)
-    defra_ruby_validators (2.2.0)
+    defra_ruby_validators (2.1.2)
       activemodel
       os_map_ref
       phonelib


### PR DESCRIPTION
We're not ready for [defra_ruby_validators](https://github.com/DEFRA/defra-ruby-validators) to be bumped yet, as we know it might break things in the app.

However we let Dependabot sneak it in, thinking it was just an engine update https://github.com/DEFRA/waste-exemptions-front-office/pull/256

So this change reverts it back to the previous version.