### PR TITLE
Further tweaks to SonarCloud config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ addons:
   sonarcloud:
     organization: "defra"
 
-env:
-  global:
-    - CC_TEST_REPORTER_ID=cc5df0d2b363a3657844597704e662adb6ee6cb578dde541af7fe742863cc543
-
 language: ruby
 rvm: 2.4.2
 cache: bundler
@@ -23,14 +19,6 @@ before_install:
   - export TZ=UTC
 
 before_script:
-  # Setup to support the CodeClimate test coverage submission
-  # As per CodeClimate's documentation, they suggest only running
-  # ./cc-test-reporter commands on travis-ci push builds only. Hence we wrap all
-  # the codeclimate test coverage related commands in a check that tests if we
-  # are in a pull request or not.
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter; fi
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then chmod +x ./cc-test-reporter; fi
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter before-build; fi
   # Replace database.yml with database.travis.yml (but leave filename as
   # database.yml). database.travis.yml is the config needed for Travis, and it
   # needs to be in place before we run the migrations.
@@ -41,6 +29,3 @@ script:
   - bundle exec rubocop --format=json --out=rubocop-result.json
   - bundle exec rspec
   - sonar-scanner
-
-after_script:
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Waste Exemptions Front Office
 
 [![Build Status](https://travis-ci.com/DEFRA/waste-exemptions-front-office.svg?branch=master)](https://travis-ci.com/DEFRA/waste-exemptions-front-office)
-[![Maintainability](https://api.codeclimate.com/v1/badges/cb98994c43b219d013e6/maintainability)](https://codeclimate.com/github/DEFRA/waste-exemptions-front-office/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/cb98994c43b219d013e6/test_coverage)](https://codeclimate.com/github/DEFRA/waste-exemptions-front-office/test_coverage)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_waste-exemptions-front-office&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=DEFRA_waste-exemptions-front-office)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_waste-exemptions-front-office&metric=coverage)](https://sonarcloud.io/dashboard?id=DEFRA_waste-exemptions-front-office)
 [![security](https://hakiri.io/github/DEFRA/waste-exemptions-front-office/master.svg)](https://hakiri.io/github/DEFRA/waste-exemptions-front-office/master)
 [![Licence](https://img.shields.io/badge/Licence-OGLv3-blue.svg)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3)
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,19 +10,21 @@ sonar.projectVersion=1.1.5
 sonar.links.homepage=https://github.com/DEFRA/waste-exemptions-front-office
 sonar.links.ci=https://travis-ci.com/DEFRA/waste-exemptions-front-office
 sonar.links.scm=https://github.com/DEFRA/waste-exemptions-front-office
+sonar.links.issue=https://github.com/DEFRA/ruby-services-team/issues
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on
 # Windows.
-sonar.sources=.
+# Because rails generates a number of files, and SonarCloud has no rails and
+# ruby intelligence we have found we have to specify what should be covered.
+# If we don't SonarCloud will do things like take the raw coverage data from
+# simplecov, compare that to all files ion the repo, and score 0 for all the
+# files we don't actually need to test. This severly deflates our scores and
+# means it is not consistent with our previous reporting tool CodeClimate.
+sonar.sources=./app,./lib,./public
+sonar.tests=./spec
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
-
-# Ignore these folders. This helped resolve a problem where SonarCloud was
-# trying to run a Java scan because it thought something in these folders was
-# Java related. An alternate would have been to update the call in .travis.yml
-# to `sonar-scanner -Dsonar.java.binaries=/tmp`
-sonar.exclusions=log/**/*,vendor/**/*
 
 sonar.ruby.coverage.reportPath=coverage/.resultset.json
 sonar.ruby.rubocop.reportPath=rubocop-result.json


### PR DESCRIPTION
In order to get what SonarCloud is reporting to match what we expect we need to make further tweaks to the configuration.

This is not about 'fixing the result'. It just seems SonarCloud is being both to clever for its own good, whilst not being as informed about frameworks like rails as a tool like CodeClimate is.

For example Rails generates a number of files when you create a new project. But we only care about the files directly related to our app, and that we actively maintain. Even Simplecov our coverage reporting tool has a rails mode which is why when run locally we get 97.96% test coverage.

SonarCloud however is ignoring the final stats SimpleCov reports and instead is comparing its line coverage information with the files it sees. It however does not have the knowledge to exclude folders like `db/`, `config/` etc, and does not seem aware that rspec is our test framework to everything in `spec/` should also be ignored.

So this change is about tweaking how things are reported to SonarCloud so it comes inline with what we have come to expect from CodeClimate.