### PR TITLE
Changes need to support switch to 'main' branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem "uglifier", ">= 1.3.0"
 # Use the waste exemptions engine for the user journey
 gem "waste_exemptions_engine",
     git: "https://github.com/DEFRA/waste-exemptions-engine",
-    branch: "master"
+    branch: "main"
 
 # bundle exec rake doc:rails generates the API under doc/api.
 gem "sdoc", "~> 1.1.0", group: :doc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/DEFRA/waste-exemptions-engine
-  revision: ee5841d913cd960353039099a06411930fed3091
-  branch: master
+  revision: 083079e2ec75fe500997c823950ea8b1777557de
+  branch: main
   specs:
     waste_exemptions_engine (0.0.1)
       aasm (~> 4.12)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Waste Exemptions Front Office
 
-[![Build Status](https://travis-ci.com/DEFRA/waste-exemptions-front-office.svg?branch=master)](https://travis-ci.com/DEFRA/waste-exemptions-front-office)
+[![Build Status](https://travis-ci.com/DEFRA/waste-exemptions-front-office.svg?branch=main)](https://travis-ci.com/DEFRA/waste-exemptions-front-office)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_waste-exemptions-front-office&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=DEFRA_waste-exemptions-front-office)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_waste-exemptions-front-office&metric=coverage)](https://sonarcloud.io/dashboard?id=DEFRA_waste-exemptions-front-office)
-[![security](https://hakiri.io/github/DEFRA/waste-exemptions-front-office/master.svg)](https://hakiri.io/github/DEFRA/waste-exemptions-front-office/master)
+[![security](https://hakiri.io/github/DEFRA/waste-exemptions-front-office/main.svg)](https://hakiri.io/github/DEFRA/waste-exemptions-front-office/main)
 [![Licence](https://img.shields.io/badge/Licence-OGLv3-blue.svg)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3)
 
 If your business produces waste or emissions that pollute you may require an environmental permit. However you may also be able to get an exemption if your business activities are considered to be easily controlled and only create low risks of pollution.
@@ -16,7 +16,7 @@ This project is the front office application which members of the public use to 
 
 ## Prequisites
 
-You'll need [Ruby 2.4.2](https://www.ruby-lang.org/en/) installed plus the [Bundler](http://bundler.io/) gem.
+You'll need [Ruby 2.7.1](https://www.ruby-lang.org/en/) installed plus the [Bundler](http://bundler.io/) gem.
 
 ## Installation
 


### PR DESCRIPTION
The ruby services team have agreed to move to the convention of using `main` instead of `master` for our default branch across all our projects.

These are the changes needed to the source code in order to support this in WEX.