### PR TITLE
Add missing Notify config

### DIFF
--- a/config/initializers/waste_exemptions_engine.rb
+++ b/config/initializers/waste_exemptions_engine.rb
@@ -35,5 +35,8 @@ WasteExemptionsEngine.configure do |configuration|
   configuration.airbrake_host = ENV["AIRBRAKE_HOST"]
   configuration.airbrake_project_key = ENV["AIRBRAKE_FO_PROJECT_KEY"]
   configuration.airbrake_blocklist = [/password/i, /authorization/i]
+
+  # Notify config
+  configuration.notify_api_key = ENV["NOTIFY_API_KEY"]
 end
 WasteExemptionsEngine.start_airbrake


### PR DESCRIPTION
The API key is required to send emails or letters from the app.