### PR TITLE
Update minimum Rails version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem "pgreset"
 gem "sassc-rails"
 
 # Bundle edge Rails instead: gem "rails', github: 'rails/rails'
-gem "rails", "~> 6.0.3.1"
+gem "rails", "~> 6.0.3.7"
 
 # # Use SCSS for stylesheets
 # gem "sass-rails", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -416,7 +416,7 @@ DEPENDENCIES
   pg (~> 0.18.4)
   pgreset
   pry-byebug
-  rails (~> 6.0.3.1)
+  rails (~> 6.0.3.7)
   rspec-rails
   sassc-rails
   sdoc (~> 1.1.0)


### PR DESCRIPTION
As part of dealing with this security issue: https://www.ruby-lang.org/en/news/2021/05/02/os-command-         injection-in-rdoc/