### PR TITLE
Cookies

### DIFF
--- a/app/controllers/cookies_controller.rb
+++ b/app/controllers/cookies_controller.rb
@@ -16,6 +16,23 @@ class CookiesController < ApplicationController
     redirect_back fallback_location: "/"
   end
 
+  def update
+    # Google writes the cookies as ".hostname"
+    # so we need to state the domain when removing
+    cookies.to_hash.each_pair do |k, _v|
+      cookies.delete k, domain: ".#{request.hostname}"
+    end
+
+    if params[:analytics] == "accept"
+      write_cookie(:cookies_policy, :analytics_accepted)
+    else
+      write_cookie(:cookies_policy, :analytics_rejected)
+    end
+    write_cookie(:cookies_preferences_set, true)
+
+    redirect_to "/pages/cookies?cookies_updated=true"
+  end
+
   protected
 
   def write_cookie(name, value)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,7 +53,7 @@
       <%= link_to "Privacy", "/fo/pages/privacy", class: "govuk-footer__link", target: "_blank" %>
     </li>
     <li class="govuk-footer__inline-list-item">
-      <%= link_to "Cookies", "/fo/pages/cookies", class: "govuk-footer__link", target: "_blank" %>
+      <%= link_to "Cookies", "/pages/cookies", class: "govuk-footer__link", target: "_blank" %>
     </li>
     <li class="govuk-footer__inline-list-item">
       <%= link_to "Accessibility", "/fo/pages/accessibility", class: "govuk-footer__link", target: "_blank" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,16 +10,7 @@
     </script>
   <% end %>
 
-  <% if ENV['GOOGLE_TAGMANAGER_ID'].present? %>
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
-      {'gtm.start': new Date().getTime(),event:'gtm.js'}
-    );var f=d.getElementsByTagName(s)[0],
-        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer', '<%= ENV["GOOGLE_TAGMANAGER_ID"] %>');</script>
-    <!-- End Google Tag Manager -->
-  <% end %>
+  <%= render partial: "shared/google_tagmanager" if ENV['GOOGLE_TAGMANAGER_ID'].present? %>
 <% end %>
 
 <% content_for :page_title, title %>

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -1,86 +1,97 @@
-<% content_for :title, "Cookies" %>
+<% content_for :title, t(".heading") %>
 
-<div class="text">
-  <h1 class="heading-large">Cookies</h1>
-  <p>The register your waste exemptions service puts small files (known as ‘cookies’) on to your computer.</p>
-  <p>These cookies are used to:</p>
+<%= form_tag "/cookies", method: :patch do %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <% if params[:cookies_updated] %>
+        <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+          <div class="govuk-notification-banner__header">
+            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+              <%= t('.updated.success') %>
+            </h2>
+          </div>
+          <div class="govuk-notification-banner__content">
+            <p class="govuk-notification-banner__heading">
+              <%= t('.updated.you_set_your_cookie_preferences') %>
+            </p>
+          </div>
+        </div>
+      <% end %>
 
-  <ul class="list list-bullet">
-    <li>help us understand how you use the service, so we can make improvements </li>
-    <li>remember what notifications you’ve seen so that you’re not shown them more than once</li>
-    <li>temporarily store the information you enter</li>
-  </ul>
-
-  <p>Find out more about <a rel="external" href="http://www.aboutcookies.org/">how to manage cookies</a></p>
-
-  <h2 class="heading-medium">Google Analytics cookie</h2>
-
-  <p>We use Google Analytics to collect information about how you use the service. This information helps us to improve the service.</p>
-  <p>The Google analytics cookie collects and stores information about:</p>
-
-  <ul class="list list-bullet">
-    <li>the pages you visit - how long you spend on each page</li>
-    <li>how you got to the service</li>
-    <li>what you click on while you’re using the service</li>
-  </ul>
-
-  <table summary="Google analytics cookie collection" role="presentation">
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Purpose</th>
-        <th>Expires</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>_ga</td>
-        <td>Used to identify unique users and inform referring sites, visitor and session counts</td>
-        <td>2 years</td>
-      </tr>
-    </tbody>
-  </table>
-
-  <p>Google isn't allowed to use or share our analytics data with anyone.</p>
-
-  <h2 class="heading-medium">Session cookie</h2>
-
-  <p>We store session cookies on your computer to help keep your information secure while you use the service.</p>
-
-  <table summary="Session cookies" role="presentation">
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Purpose</th>
-        <th>Expires</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>_waste-exemptions_session</td>
-        <td>Used for session management and authentication</td>
-        <td>When you close your browser</td>
-      </tr>
-    </tbody>
-  </table>
-
-  <h2 class="heading-medium">Introductory message cookie</h2>
-  <p>When you first use the service, you may see a cookie message appear at the top of the screen. Once you’ve seen the message, we store a cookie on your computer so it knows not to show it again. </p>
-
-  <table summary="Introductory message cookie" role="presentation">
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Purpose</th>
-        <th>Expires</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>seen_cookie_message</td>
-        <td>Stores a message to let us know that you have seen our cookie message</td>
-        <td>1 month</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
+      <h1 class="govuk-heading-l"><%= t('.heading') %></h1>
+      <p class="govuk-body"><%= t('.text_1') %></p>
+      <p class="govuk-body"><%= t('.text_2') %></p>
+      <h2 class="govuk-heading-m"><%= t('.cookie_settings.subheading') %></h2>
+      <p class="govuk-body"><%= t('.cookie_settings.text_1') %></p>
+      <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+          <h2 class="govuk-body govuk-!-font-weight-bold"><%= t('.analytics_cookies.subheading') %></h2>
+          <p class="govuk-body"><%= t('.analytics_cookies.text_1') %></p>
+          <p class="govuk-body"><%= t('.analytics_cookies.text_2') %></p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li><%= t('.analytics_cookies.list_item_1') %></li>
+            <li><%= t('.analytics_cookies.list_item_2') %></li>
+            <li><%= t('.analytics_cookies.list_item_3') %></li>
+          </ul>
+        </legend>
+        <div class="govuk-radios">
+          <div class="govuk-radios__item">
+            <%= radio_button_tag :analytics, :accept,
+                (cookies[:cookies_policy] && cookies[:cookies_policy] == "analytics_accepted"),
+                class: "govuk-radios__input" %>
+            <%= label_tag :analytics_accept,
+                t('.analytics_cookies.radio_button_label.accept'),
+                class: "govuk-label govuk-radios__label" %>
+          </div>
+          <div class="govuk-radios__item">
+            <%= radio_button_tag :analytics, :reject,
+                !(cookies[:cookies_policy] && cookies[:cookies_policy] == "analytics_accepted"),
+                class: "govuk-radios__input" %>
+            <%= label_tag :analytics_reject,
+                t('.analytics_cookies.radio_button_label.reject'),
+                class: "govuk-label govuk-radios__label" %>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+    <h2 class="govuk-heading-m"><%= t('.essential_cookies.subheading') %></h2>
+    <p class="govuk-body"><%= t('.essential_cookies.text_1') %></p>
+    <p class="govuk-body"><%= t('.essential_cookies.text_2') %></p>
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m">
+        <%= t('.cookies_we_use.subheading') %>
+      </caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">
+            <%= t('.cookies_we_use.name') %>
+          </th>
+          <th scope="col" class="govuk-table__header">
+            <%= t('.cookies_we_use.purpose') %>
+          </th>
+          <th scope="col" class="govuk-table__header">
+            <%= t('.cookies_we_use.expires') %>
+          </th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% %i{ ga gid cookies_policy cookies_preferences_set registrations_session }.each do |cookie| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+              <%= t(".cookies_we_use.#{cookie}.name") %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= t(".cookies_we_use.#{cookie}.purpose") %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= t(".cookies_we_use.#{cookie}.expires") %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <p class="govuk-body"><%= link_to t('.find_out_more.text'), t('.find_out_more.url') %></p>
+    <%= submit_tag t('.submit_button'), class: "govuk-button" %>
+  </div>
+<% end %>

--- a/app/views/shared/_google_tagmanager.html.erb
+++ b/app/views/shared/_google_tagmanager.html.erb
@@ -1,0 +1,10 @@
+<% if cookies[:cookies_policy] == 'analytics_accepted' %>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
+    {'gtm.start': new Date().getTime(),event:'gtm.js'}
+  );var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer', '<%= ENV["GOOGLE_TAGMANAGER_ID"] %>');</script>
+  <!-- End Google Tag Manager -->
+<% end %>

--- a/config/locales/cookies.en.yml
+++ b/config/locales/cookies.en.yml
@@ -1,0 +1,56 @@
+---
+en:
+  pages:
+    cookies:
+      heading: Cookie settings
+      text_1: Cookies are files saved on your phone, table or computer when you visit a website.
+      text_2: We use cookies to store information about how you use the Register your Waste Exemptions website.
+      cookie_settings:
+        subheading: Cookie settings
+        text_1: We use 2 types of cookie. You can choose which cookies you're happy for us to use.
+      analytics_cookies:
+        subheading: Cookies that measure website use
+        text_1: We use Google Analytics to measure how you use the website so we can improve it based on user needs. We do not allow Google to use or share the data about how you use this site.
+        text_2: 'Google Analytics sets cookies that store anonymised information about:'
+        list_item_1: how you got to the site
+        list_item_2: the pages you visit on Register your Waste Exemptions, and how long you spend on each page
+        list_item_3: what you click on while you're visiting the site
+        radio_button_label:
+          accept: Use cookies that measure my website use
+          reject: Do not use cookies that measure my website use
+      essential_cookies:
+        subheading: Strictly necessary cookies
+        text_1: These essential cookies do things like remember your progress through a form.
+        text_2: They will always be on.
+      cookies_we_use:
+        subheading: All the cookies we use
+        name: Name
+        purpose: Purpose
+        expires: Expires
+        ga:
+          name: _ga
+          purpose: Used to identify referring sites, visitors and sessions
+          expires: 2 years
+        gid:
+          name: _gid
+          purpose: Tells us how visitors use the service, where they came from and the pages visited
+          expires: 24 hours
+        registrations_session:
+          name: _waste-exemptions-front-office_session
+          purpose: Used for session management and authentication
+          expires: When you close your browser
+        cookies_policy:
+          name: cookies_policy
+          purpose: Saves your cookie consent settings
+          expires: 1 year
+        cookies_preferences_set:
+          name: cookies_preferences_set
+          purpose: Tells us about your cookie settings
+          expires: 1 year
+      find_out_more:
+        text: Find out more about cookies on GOV.UK
+        url: https://www.gov.uk/help/cookie-details
+      submit_button: Save and continue
+      updated:
+        success: success
+        you_set_your_cookie_preferences: You’ve set your cookie preferences.

--- a/spec/features/cookies_spec.rb
+++ b/spec/features/cookies_spec.rb
@@ -24,12 +24,22 @@ RSpec.describe "Cookies", type: :feature do
     expect(page.source).to have_text(google_analytics_render_tag)
   end
 
-  scenario "User rejects analytics cookies" do
+  scenario "User rejects analytics cookies and toggles their selection" do
     visit root_path
     click_on "Reject analytics cookies"
     expect(page).to have_text("You’ve rejected analytics cookies")
+    expect(page.source).not_to have_text(google_analytics_render_tag)
 
-    click_on "Hide this message"
+    click_on "change your cookie settings"
+    expect(page).to have_css("h1", text: "Cookie settings")
+
+    choose "Use cookies that measure my website use"
+    click_on "Save and continue"
+    expect(page.source).to have_text(google_analytics_render_tag)
+    expect(page).to have_text("You’ve set your cookie preferences.")
+
+    choose "Do not use cookies that measure my website use"
+    click_on "Save and continue"
     expect(page.source).not_to have_text(google_analytics_render_tag)
   end
 end

--- a/spec/features/cookies_spec.rb
+++ b/spec/features/cookies_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 RSpec.describe "Cookies", type: :feature do
+  before { ENV["GOOGLE_TAGMANAGER_ID"] = "GA_ID" }
+
   let(:cookie_banner_div) { ".govuk-cookie-banner" }
+  let(:google_analytics_render_tag) { "function(w,d,s,l,i)" }
 
   scenario "User accepts analytics cookies" do
     visit root_path
@@ -18,11 +21,15 @@ RSpec.describe "Cookies", type: :feature do
     end
 
     expect(page).not_to have_css(cookie_banner_div)
+    expect(page.source).to have_text(google_analytics_render_tag)
   end
 
   scenario "User rejects analytics cookies" do
     visit root_path
     click_on "Reject analytics cookies"
     expect(page).to have_text("You’ve rejected analytics cookies")
+
+    click_on "Hide this message"
+    expect(page.source).not_to have_text(google_analytics_render_tag)
   end
 end


### PR DESCRIPTION
This PR includes the following commits (that can be rebased+merged):

Enable Goggle Tagmanager script (Make cookie consent banner functional)
https://eaflood.atlassian.net/browse/RUBY-1534

Update cookie policy to match Design System standard
https://eaflood.atlassian.net/browse/RUBY-1657

Allow users to update cookie settings after initial selection
https://eaflood.atlassian.net/browse/RUBY-1658