### PR TITLE
Styling: Privacy policy page header

### DIFF
--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="heading-large">
+    <h1 class="govuk-heading-l">
       Privacy Notice: how we use your personal data
     </h1>
 


### PR DESCRIPTION
This fixes the un-styled `<h1>`