### PR TITLE
Bump loofah gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,7 @@ GEM
       thor (>= 0.14, < 2.0)
     json (2.3.0)
     jwt (2.3.0)
-    loofah (2.13.0)
+    loofah (2.2.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)


### PR DESCRIPTION
- In response to:
`loofah gem 2.13.0 is vulnerable (CVE-2018-8048). Upgrade to 2.2.1`