### PR TITLE
Feature/ruby 1724 cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ end
 group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem "spring"
+  gem "spring-commands-rspec"
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem "web-console", "~> 2.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,7 +218,7 @@ GEM
       thor (>= 0.14, < 2.0)
     json (2.3.0)
     jwt (2.3.0)
-    loofah (2.2.1)
+    loofah (2.13.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -365,6 +365,8 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     spring (4.0.0)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -428,6 +430,7 @@ DEPENDENCIES
   secure_headers (~> 5.0)
   simplecov (~> 0.17.1)
   spring
+  spring-commands-rspec
   turbolinks
   uglifier (>= 1.3.0)
   waste_exemptions_engine!

--- a/app/helpers/data_layer_helper.rb
+++ b/app/helpers/data_layer_helper.rb
@@ -26,12 +26,12 @@ module DataLayerHelper
   end
 
   def data_layer_value_by_type(transient_registration)
-    case transient_registration.class.name
-    when "WasteExemptionsEngine::EditRegistration"
+    case transient_registration
+    when WasteExemptionsEngine::EditRegistration
       :edit
-    when "WasteExemptionsEngine::NewRegistration"
+    when WasteExemptionsEngine::NewRegistration
       :new
-    when "WasteExemptionsEngine::RenewingRegistration"
+    when WasteExemptionsEngine::RenewingRegistration
       :renew
     end
   end

--- a/config.ru
+++ b/config.ru
@@ -2,5 +2,5 @@
 
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path("../config/environment", __FILE__)
+require ::File.expand_path("../config/environment", __dir__)
 run Rails.application


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1724
This change cleans up some minor issues which were observed when testing the waste-exemptions-engine changes under ruby-1724.
It enables rspec under spring and addresses some deprecation and Rubocop warnings.