### PR TITLE
revert file loading syntax change in config.ru

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -2,5 +2,5 @@
 
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path("../config/environment", __dir__)
+require ::File.expand_path("../config/environment", __FILE__)
 run Rails.application


### PR DESCRIPTION
This change reverts a change to config.ru which changed the syntax for sourcing config/environment.rb. The original change was made in response to a Rubocop warning.