### PR TITLE
Companies House data retrieval

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -54,6 +54,10 @@ module WasteExemptionsFrontOffice
     config.front_office_url = ENV["FRONT_OFFICE_URL"] || "http://localhost:3000"
     config.back_office_url = ENV["BACK_OFFICE_URL"] || "http://localhost:8000"
 
+    # Companies house API config
+    config.companies_house_host = ENV["COMPANIES_HOUSE_URL"] || "https://api.companieshouse.gov.uk/company/"
+    config.companies_house_api_key = ENV["COMPANIES_HOUSE_API_KEY"]
+
     # Emails
     config.email_test_address = ENV["EMAIL_TEST_ADDRESS"]
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_08_160306) do
+ActiveRecord::Schema.define(version: 2022_05_10_134655) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -197,6 +197,11 @@ ActiveRecord::Schema.define(version: 2021_03_08_160306) do
     t.datetime "updated_at", null: false
     t.string "type", null: false
     t.boolean "temp_renew_without_changes"
+    t.boolean "temp_reuse_applicant_phone"
+    t.boolean "temp_reuse_applicant_email"
+    t.boolean "temp_reuse_operator_address"
+    t.string "temp_reuse_address_for_site_location"
+    t.boolean "temp_use_registered_company_details"
     t.index ["token"], name: "index_transient_registrations_on_token", unique: true
   end
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1872

Here we have the users company house number being used to validate that the company is active and return the company name and address for the user to confirm it is indeed their company. If the user confirms this then the name name registered on company's house will be used as the operator name for the service. If the user doesn't confirm these details then they are asked to change them via company house