### PR TITLE
Reinstate html_safe

### DIFF
--- a/app/helpers/data_layer_helper.rb
+++ b/app/helpers/data_layer_helper.rb
@@ -8,7 +8,9 @@ module DataLayerHelper
       output << "'#{key}': '#{value}'"
     end
 
-    ActionController::Base.helpers.sanitize(output.join(","))
+    # rubocop:disable Rails/OutputSafety
+    output.join(",").html_safe
+    # rubocop:enable Rails/OutputSafety
   end
 
   private

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,9 +40,11 @@ module WasteExemptionsFrontOffice
     # Don't add field_with_errors div wrapper around fields with errors. When
     # rails does this it messes with the GOV.UK styling and causes checkboxes
     # and radio buttons to become invisible
+    # rubocop:disable Rails/OutputSafety
     config.action_view.field_error_proc = proc { |html_tag, _instance|
-      ActionController::Base.helpers.sanitize(html_tag.to_s)
+      html_tag.to_s.html_safe
     }
+    # rubocop:enable Rails/OutputSafety
 
     # https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#active-record-belongs-to-required-by-default-option
     config.active_record.belongs_to_required_by_default = false


### PR DESCRIPTION
This change reverts from sanitize to html_safe to resolve issues with form error handling.
https://eaflood.atlassian.net/browse/RUBY-2161